### PR TITLE
Fix BoardContext compilation break on develop

### DIFF
--- a/applications/nucleo-demo/include/Demo.hpp
+++ b/applications/nucleo-demo/include/Demo.hpp
@@ -13,7 +13,6 @@
 #include "jarnax/Ticker.hpp"
 #include "jarnax/Timer.hpp"
 #include "jarnax/i2c/Driver.hpp"
-#include "jarnax/net/ethernet/Driver.hpp"
 #include "jarnax/usart/Driver.hpp"
 
 using jarnax::Loopable;

--- a/applications/nucleo-demo/source/GlobalContext.cpp
+++ b/applications/nucleo-demo/source/GlobalContext.cpp
@@ -30,7 +30,7 @@ public:
         result &= GetSuperLoop().Enlist(jarnax::GetBoardContext().GetI2cB());
         result &= GetSuperLoop().Enlist(jarnax::GetBoardContext().GetSpiA());
         result &= GetSuperLoop().Enlist(jarnax::GetBoardContext().GetUsartB());
-        result &= GetSuperLoop().Enlist(jarnax::GetBoardContext().GetEthernet());
+        // result &= GetSuperLoop().Enlist(jarnax::GetBoardContext().GetEthernet());
         result &= GetSuperLoop().Enlist(console_);
         if (result) {
             return core::Status{};

--- a/boards/nucleo_h753zi/include/BoardContext.hpp
+++ b/boards/nucleo_h753zi/include/BoardContext.hpp
@@ -86,7 +86,7 @@ public:
     jarnax::console::Service& GetConsole();
 
     /// Return the Ethernet Driver
-    jarnax::net::ethernet::Driver& GetEthernet();
+    // jarnax::net::ethernet::Driver& GetEthernet();
 
 protected:
     stm32::Timer timer_;

--- a/boards/nucleo_h753zi/source/BoardContext.cpp
+++ b/boards/nucleo_h753zi/source/BoardContext.cpp
@@ -1,6 +1,7 @@
 #include <compiler.hpp>
 
 #include "BoardContext.hpp"
+#include <cortex/linker.hpp>
 #include "configure.hpp"
 #include "cortex/mcu.hpp"
 #include "jarnax.hpp"


### PR DESCRIPTION
This PR fixes the compilation break of the target/board libraries on the `develop` branch.

### Changes
* Included `<cortex/linker.hpp>` in `BoardContext.cpp` to correctly define the `LINKER_TYPED_SYMBOL` macro.
* Commented out the premature `GetEthernet()` declaration in `BoardContext.hpp` and its enlistment in `GlobalContext.cpp` since the network stack files are not yet present on `develop`.
* Removed the unused `jarnax/net/ethernet/Driver.hpp` header inclusion from `Demo.hpp`.

Closes #35