### PR TITLE
nucleo-cyphal: serve uavcan.node.GetInfo (430) via libudpard RPC dispatcher

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -38,3 +38,30 @@
   `sudo chmod` after `USER dev` is broken under buildx (setuid stripped, "effective uid is not
   0"). Fixed by creating the catalog 0644 for `dev`, appending without sudo, and restoring
   `chmod 444` as root. Alpine/Debian/Arch Containerfiles still use the old sudo pattern.
+
+## 2026-08-08 — nunavut-generated `initialize_()` trips GCC `-Warray-bounds` when called in firmware
+
+- **Symptom:** `error: array subscript 536870911 is outside array bounds of 'const uint8_t [1]'`
+  in the generated `GetInfo_1_0.h`, `-Werror` (with `-O2`) during the M7 ARM build. Fails in
+  the *caller*, not the header — the `-isystem` path does not suppress it.
+- **Root cause:** `uavcan_node_GetInfo_Response_1_0_initialize_()` inlines a
+  `deserialize_()` fed a 1-byte stack buffer; unguarded `nunavutGetU64(&buffer[0], ...)`
+  reads past it. Heartbeat's generated code happens to be bounds-guarded, so it compiles fine.
+- **Fix:** do not call the generated `initialize_()` for Getinfo responses in firmware; instead
+  `std::memset(&info, 0, sizeof(info))` — all GetInfo defaults are zero, so the result is
+  identical. (Host tests keep `initialize_()`; LLVM/AppleClang do not flag the pattern.)
+
+## 2026-08-08 — `HyphaIpIsSameIPv4Address` is not exported by the public `hypha_ip.h`
+
+- **Symptom:** link/compile error referencing `HyphaIpIsSameIPv4Address` from app code that
+  includes only `hypha_ip/hypha_ip.h`.
+- **Root cause:** the helper is declared in `third-party/libhypha/source/include/hypha_ip/hypha_internal.h`
+  (internal translation units) and not re-exported publicly.
+- **Fix:** on-target code compares `HyphaIpIPv4Address_t` directly with a local
+  `std::memcmp`/`==` helper (the struct is exactly `sizeof(uint32_t)`).
+
+## 2026-08-08 — `on-host-native-gcc` preset cannot build on macOS/Darwin
+
+- `g++-13` (homebrew) does not provide `cstddef`/libc++ headers, so any `module-core` TU fails
+  with `fatal error: cstddef: No such file or directory`. This is pre-existing and unrelated to
+  this change; AGENTS.md documents that the GCC host preset only works on Linux.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,84 @@
+# PLAN: uavcan.node.GetInfo service server in CyphalApp
+
+Issue: #44 (server half) — branch `issue-44` (tracks `develop`).
+Depends/scope: this PR is **server only**; the client scanner is a separate issue (#45).
+
+## Summary
+
+Add the service-side half of `uavcan.node.GetInfo.1.0` (fixed port-ID `430`) to the
+`nucleo::cyphal::CyphalApp` in `applications/nucleo-cyphal`. The app already publishes a
+Heartbeat on subject 7509 (publisher) and has a libudpard v1 subscription. We need to also:
+
+1. Create a `UdpardRxRPCDispatcher` (one per node) initialized with the same O1Heap-backed
+   memory resources as the existing subject subscription.
+2. Register one service **request** RX port for `430` so requests addressed to our node-ID
+   are accepted/reassembled.
+3. Route incoming UDP datagrams to the *subject subscription* or the *RPC dispatcher* based
+   on `metadata.destination_address` (subject multicast 239.255.x vs service multicast 239.1.0.<node_id>).
+4. Register the service membership for `239.1.0.<node_id>` (via `HyphaIpPrepareUdpReceive`),
+   so multicast requests from scanners (e.g. yakut / bus-monitor) are delivered.
+5. On a completed request: build a `uavcan_node_GetInfo_Response_1_0` with an **assigned**
+   node name / versions / unique-id (hard-coded constants for now), serialize it, and
+   `udpardTxRespond` using the same service-ID, the request's client node-ID and its transfer-ID.
+
+## Design decisions
+
+- **Assigned identity**: per requirement the unique-ID / name / versions are assigned
+  (not MAC-derived):
+  - name = `com.emrainey.superloop.nucleo` (DSDL allowed charset: `.` `-` `_` and a-z0-9).
+  - protocol_version = {1, 0}, hardware_version kept {0,0} for now.
+  - software_vcs_revision_id = 0 (TBD) — can be filled later.
+  - unique_id = `{0xDE,0xAD,0xBE,0xEF,0x10..0xC0}` 16 bytes (assigned).
+- **Membership**: Reuse `HyphaIpPrepareUdpReceive` with the dispatcher's derived endpoint
+  (`239.1.0.103`). The ETH MPL filter in `Execute()` already whitelists the service multicast
+  group — keep it there.
+- **Transport flow**: `OnReceiveUdp` stays as-is except a new early branch that detects
+  service-multicast datagrams via the cached group address. `ProcessTransmitQueue()` already
+  drains whatever `udpardTxRequest/Respond` enqueues, so responses transmit via the existing
+  UDP TX path.
+- **TID / deadlines**: match existing heartbeat style (`udpardTxRespond(&tx_, now+..., prio,
+  service_id, client_node_id, transfer_id, payload, user_reference)`).
+
+## Steps
+
+1. Write a Catch2 host test file `catch2-cyphal-getinfo-server.cpp` covering:
+   - GetInfo Request serialization → 0 bytes (sealed), deserialize no-op.
+   - GetInfo Response serialize/deserialize round trip incl. vcs, unique_id, name.
+2. Implement in `CyphalApp`:
+   - Members: `UdpardRxRPCDispatcher service_dispatcher_`, `UdpardRxRPCPort get_info_service_port_`,
+     cached `HyphaIpIPv4Address_t service_group_address_`, `bool service_initialized_`.
+   - New `ServiceDispatcherInit()`: init + start dispatcher (port 430, is_request=true),
+     store the group IP, join membership.
+   - In `Execute()`: lazy-init the dispatcher once udpard is running.
+   - In `OnReceiveUdp`: compare `metadata.destination_address` against the cached group; if
+     equal → `udpardRxRPCDispatcherReceive`, else subject subscription.
+   - New `ServiceResponseHandler(...)` that, on `is_request && service_id==430`, constructs the
+     response and `udpardTxRespond`s.
+3. Update CMake test list (add the new Catch2 file).
+4. Build / test hosts + cross, then build-all-presets + act.
+
+## Progress
+
+- [x] Host unit test file written and passing (`test-cyphal-getinfo-server-none-all`,
+      4 tests / 21 assertions) on LLVM and AppleClang.
+- [x] `ServiceDispatcherInit()` implemented; lazy-called from `Execute()`.
+- [x] `OnReceiveUdp` routes service-multicast datagrams to the RPC dispatcher.
+- [x] `ServiceResponseHandler()` builds the assigned response and `udpardTxRespond`s.
+- [x] M7 firmware compiles + links; M4 workflow builds; all LLVM/AppleClang host tests pass.
+- [ ] GOTCHAS entries, build-all-presets, act, commit, PR.
+
+## Gotchas (add to GOTCHAS)
+
+- Generated `GetInfo_1_0.h` `initialize_()` inlines a `deserialize_` from a 1-byte stack buffer;
+  GCC's `-Warray-bounds` (with `-Werror`) rejects it. Workaround: `memset` the response to zero
+  instead of calling `uavcan_node_GetInfo_Response_1_0_initialize_()` (all defaults are zero).
+- `HyphaIpIsSameIPv4Address` is declared only in `hypha_internal.h`, not the public
+  `hypha_ip.h`; use a local `memcmp`-based helper instead.
+- Udpard v1: server reuses the request's transfer-ID in the response (client-side transfer
+  tracking is out of scope; see #45).
+
+## Out of scope (see #45)
+
+- Client scanner: registering a response port, per-server transfer counters, scanning
+  *several* node IDs, and logging the arriving responses.
+EOF

--- a/applications/nucleo-cyphal/include/CyphalApp.hpp
+++ b/applications/nucleo-cyphal/include/CyphalApp.hpp
@@ -23,6 +23,7 @@ public:
 
     static constexpr uint16_t UdpPort = 9382U;
     static constexpr uint32_t SubjectId = 7509U;
+    static constexpr UdpardPortID GetInfoServiceId = 430U;
     static constexpr std::size_t MaxUdpPayload = 1400U;
     // Cyphal/UDP binds the node-ID to the last octet of the node's source IP.
     static constexpr UdpardNodeID NodeId = 103U;
@@ -48,6 +49,8 @@ protected:
     void InitUdpard();
     void PublishHeartbeat();
     void ProcessTransmitQueue();
+    void ServiceDispatcherInit();
+    void ServiceResponseHandler(struct UdpardRxRPCTransfer const& transfer);
 
     static UdpardMicrosecond NowUs(jarnax::Ticker const& ticker);
 
@@ -72,11 +75,15 @@ protected:
     UdpardRxSubscription subscription_;
     struct UdpardMemoryResource tx_memory_;
     struct UdpardRxMemoryResources rx_memory_;
+    struct UdpardRxRPCDispatcher service_dispatcher_;
+    struct UdpardRxRPCPort get_info_service_port_;
+    HyphaIpIPv4Address_t service_group_address_;
 
     bool udpard_initialized_;
     bool arp_announced_;
     bool initialized_;
     bool filter_installed_;
+    bool service_initialized_;
     size_t stats_print_counter_;
     UdpardTransferID heartbeat_transfer_id_;
     jarnax::Ticks last_heartbeat_ticks_;

--- a/applications/nucleo-cyphal/source/CyphalApp.cpp
+++ b/applications/nucleo-cyphal/source/CyphalApp.cpp
@@ -11,6 +11,7 @@
 #include "stm32/h7xx/ethernet/Driver.hpp"
 #include "strings.hpp"
 
+#include "uavcan/node/GetInfo_1_0.h"
 #include "uavcan/node/Heartbeat_1_0.h"
 
 #include <cstdarg>
@@ -83,6 +84,11 @@ void UdpardFree(void* context, size_t size, void* pointer) {
     o1heapFree(heap, pointer);
 }
 
+bool SameIPv4Address(HyphaIpIPv4Address_t const& a, HyphaIpIPv4Address_t const& b) {
+    static_assert(sizeof(a) == sizeof(uint32_t), "Must be exactly this size");
+    return std::memcmp(&a, &b, sizeof(a)) == 0;
+}
+
 }    // namespace
 
 namespace nucleo {
@@ -104,10 +110,14 @@ CyphalApp::CyphalApp(jarnax::Ticker& ticker, jarnax::BoardContext& board_context
     , subscription_{}
     , tx_memory_{}
     , rx_memory_{}
+    , service_dispatcher_{}
+    , get_info_service_port_{}
+    , service_group_address_{}
     , udpard_initialized_{false}
     , arp_announced_{false}
     , initialized_{false}
     , filter_installed_{false}
+    , service_initialized_{false}
     , stats_print_counter_{0U} {
     for (auto& in_use : frame_in_use_) {
         in_use = false;
@@ -194,6 +204,12 @@ bool CyphalApp::Execute() {
         rtt::control_block.GetUp(0).Clear();
     }
 
+    // Lazy-init the service dispatcher after udpard is running
+    if (!service_initialized_) {
+        ServiceDispatcherInit();
+        service_initialized_ = true;
+    }
+
     HyphaIpRunOnce(hypha_context_);
 
     ProcessTransmitQueue();
@@ -277,6 +293,54 @@ void CyphalApp::InitUdpard() {
     HyphaIpPrepareUdpReceive(hypha_context_, subject_ip, UdpPort);
 
     jarnax::print("CyphalApp: udpard v1 initialized\r\n");
+}
+
+void CyphalApp::ServiceDispatcherInit() {
+    O1HeapInstance& heap = O1HeapPool::Instance();
+
+    // The RPC dispatcher shares the same O1Heap-backed memory resources as the subjects pipeline.
+    struct UdpardMemoryResource const memory = {
+        .user_reference = &heap,
+        .deallocate = &UdpardFree,
+        .allocate = &UdpardAlloc,
+    };
+    struct UdpardRxMemoryResources const dispatcher_memory = {
+        .session = memory,
+        .fragment = memory,
+        .payload = {
+            .user_reference = &heap,
+            .deallocate = &UdpardFree,
+        },
+    };
+
+    int_fast8_t const dispatcher_init = udpardRxRPCDispatcherInit(&service_dispatcher_, dispatcher_memory);
+    if (dispatcher_init < 0) {
+        jarnax::print("CyphalApp: udpardRxRPCDispatcherInit failed with %d\r\n", static_cast<int>(dispatcher_init));
+        return;
+    }
+
+    // The dispatcher derives the service-UDP multicast group from the local node-ID.
+    struct UdpardUDPIPEndpoint service_endpoint{};
+    int_fast8_t const dispatcher_start = udpardRxRPCDispatcherStart(&service_dispatcher_, node_id_, &service_endpoint);
+    if (dispatcher_start < 0) {
+        jarnax::print("CyphalApp: udpardRxRPCDispatcherStart failed with %d\r\n", static_cast<int>(dispatcher_start));
+        return;
+    }
+    service_group_address_ = U32ToHyphaIp(service_endpoint.ip_address);
+
+    // The service request port for uavcan.node.GetInfo (request direction = is_request=true).
+    int_fast8_t const listen =
+        udpardRxRPCDispatcherListen(&service_dispatcher_, &get_info_service_port_, GetInfoServiceId, true,
+                                    uavcan_node_GetInfo_Response_1_0_EXTENT_BYTES_);
+    if (listen < 0) {
+        jarnax::print("CyphalApp: udpardRxRPCDispatcherListen failed with %d\r\n", static_cast<int>(listen));
+        return;
+    }
+
+    // Join the service multicast group so incoming service requests are accepted.
+    HyphaIpPrepareUdpReceive(hypha_context_, service_group_address_, UdpPort);
+
+    jarnax::print("CyphalApp: GetInfo service (430) initialized\r\n");
 }
 
 void CyphalApp::OnFrameReceived(jarnax::net::ethernet::Frame* frame) {
@@ -418,6 +482,22 @@ HyphaIpStatus_e CyphalApp::OnReceiveUdp(HyphaIpExternalContext_t context, HyphaI
     payload.data = copy;
     payload.size = payload_size;
 
+    if (SameIPv4Address(metadata->destination_address, self->service_group_address_)) {
+        // Service multicast datagram (e.g. a GetInfo request addressed to this node).
+        if (self->service_initialized_) {
+            struct UdpardRxRPCTransfer transfer{};
+            int_fast8_t const result = udpardRxRPCDispatcherReceive(
+                &self->service_dispatcher_, NowUs(self->ticker_), payload, 0U, nullptr, &transfer);
+            if (result > 0) {
+                self->ServiceResponseHandler(transfer);
+                udpardRxFragmentFree(transfer.base.payload, self->rx_memory_.fragment, self->rx_memory_.payload);
+            }
+        } else {
+            o1heapFree(&heap, copy);
+        }
+        return HyphaIpStatusOk;
+    }
+
     struct UdpardRxTransfer transfer;
     udpardRxSubscriptionReceive(&self->subscription_, NowUs(self->ticker_), payload, 0U, &transfer);
 
@@ -456,6 +536,52 @@ void CyphalApp::ProcessTransmitQueue() {
             break;    // do not spin; retry on the next Execute cycle
         }
     }
+}
+
+void CyphalApp::ServiceResponseHandler(struct UdpardRxRPCTransfer const& transfer) {
+    // Only respond to GetInfo *requests* (is_request == true) for our service.
+    if (!transfer.is_request || transfer.service_id != GetInfoServiceId) {
+        return;
+    }
+
+    uavcan_node_GetInfo_Response_1_0 info{};
+    std::memset(&info, 0, sizeof(info));    // All GetInfo defaults are zero; avoids the generated deserialize init.
+
+    // Assigned node identification for now (not MAC-derived).
+    info.protocol_version.major = 1U;
+    info.protocol_version.minor = 0U;
+    info.software_version.major = 1U;
+    info.software_version.minor = 0U;
+    info.software_vcs_revision_id = 0U;
+
+    static constexpr char const NodeName[] = "com.emrainey.superloop.nucleo";
+    info.name.count = sizeof(NodeName) - 1U;
+    std::memcpy(info.name.elements, NodeName, info.name.count);
+
+    uint8_t const assigned_unique_id[16U] = {0xDEU, 0xADU, 0xBEU, 0xEFU, 0x10U, 0x20U, 0x30U, 0x40U,
+                                             0x50U, 0x60U, 0x70U, 0x80U, 0x90U, 0xA0U, 0xB0U, 0xC0U};
+    std::memcpy(info.unique_id, assigned_unique_id, sizeof(assigned_unique_id));
+
+    uint8_t buffer[uavcan_node_GetInfo_Response_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_]{};
+    size_t serialized_size = sizeof(buffer);
+    int8_t const err = uavcan_node_GetInfo_Response_1_0_serialize_(&info, buffer, &serialized_size);
+    if (err < 0) {
+        return;
+    }
+
+    struct UdpardPayload const payload = {
+        .size = serialized_size,
+        .data = buffer,
+    };
+
+    int32_t const result = udpardTxRespond(&tx_, NowUs(ticker_) + 1000000U, UdpardPriorityNominal, GetInfoServiceId,
+                                           transfer.base.source_node_id, transfer.base.transfer_id, payload, this);
+    jarnax::print(
+        "CyphalApp: GetInfo response sent=%d to node %u service_id=%u\r\n",
+        static_cast<int>(result),
+        static_cast<unsigned>(static_cast<uint16_t>(transfer.base.source_node_id)),
+        static_cast<unsigned>(transfer.service_id)
+    );
 }
 
 void CyphalApp::PublishHeartbeat() {

--- a/applications/nucleo-cyphal/tests/CMakeLists.txt
+++ b/applications/nucleo-cyphal/tests/CMakeLists.txt
@@ -7,3 +7,13 @@ host_unit_test(NAME cyphal-heartbeat
     NO_CONFIGURATIONS
     NO_BOARDS
 )
+
+host_unit_test(NAME cyphal-getinfo-server
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/catch2-cyphal-getinfo-server.cpp
+    LIBRARIES
+        cyphal-dsdl
+    CATCH2
+    NO_CONFIGURATIONS
+    NO_BOARDS
+)

--- a/applications/nucleo-cyphal/tests/catch2-cyphal-getinfo-server.cpp
+++ b/applications/nucleo-cyphal/tests/catch2-cyphal-getinfo-server.cpp
@@ -1,0 +1,90 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "uavcan/node/GetInfo_1_0.h"
+
+#include <cstdint>
+#include <cstring>
+
+namespace {
+
+uavcan_node_GetInfo_Response_1_0 MakeAssignedResponse() {
+    uavcan_node_GetInfo_Response_1_0 info{};
+    uavcan_node_GetInfo_Response_1_0_initialize_(&info);
+
+    info.protocol_version.major = 1U;
+    info.protocol_version.minor = 0U;
+
+    info.hardware_version.major = 0U;
+    info.hardware_version.minor = 0U;
+
+    info.software_version.major = 1U;
+    info.software_version.minor = 0U;
+
+    info.software_vcs_revision_id = 0U;
+
+    uint8_t const unique_id[16U] = {0xDEU, 0xADU, 0xBEU, 0xEFU, 0x00U, 0x01U, 0x02U, 0x03U,
+                                    0x10U, 0x11U, 0x12U, 0x13U, 0x20U, 0x21U, 0x22U, 0x23U};
+    std::memcpy(info.unique_id, unique_id, sizeof(unique_id));
+
+    char const name[] = "com.emrainey.superloop.nucleo";
+    info.name.count = sizeof(name) - 1U;    // exclude the NUL terminator
+    std::memcpy(info.name.elements, name, info.name.count);
+    return info;
+}
+
+// The GetInfo request is sealed; its serialized payload is always empty (zero bytes).
+TEST_CASE("GetInfo Request serializes to zero bytes", "[cyphal][getinfo][request]") {
+    uavcan_node_GetInfo_Request_1_0 request{};
+    uavcan_node_GetInfo_Request_1_0_initialize_(&request);
+
+    uint8_t buffer[uavcan_node_GetInfo_Request_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_ + 4U]{0xAAU, 0xBBU};
+    size_t size = sizeof(buffer);
+    REQUIRE(uavcan_node_GetInfo_Request_1_0_serialize_(&request, buffer, &size) == NUNAVUT_SUCCESS);
+    REQUIRE(size == 0U);
+}
+
+TEST_CASE("GetInfo Request deserialize is a no-op", "[cyphal][getinfo][request]") {
+    uint8_t const data[] = {0x01U, 0x02U, 0x03U};
+    uavcan_node_GetInfo_Request_1_0 request{};
+    uavcan_node_GetInfo_Request_1_0_initialize_(&request);
+    size_t size = sizeof(data);
+    REQUIRE(uavcan_node_GetInfo_Request_1_0_deserialize_(&request, data, &size) == NUNAVUT_SUCCESS);
+    REQUIRE(size == 0);
+}
+
+TEST_CASE("GetInfo Response round-trips the assigned fields", "[cyphal][getinfo][response]") {
+    uavcan_node_GetInfo_Response_1_0 info = MakeAssignedResponse();
+
+    uint8_t buffer[uavcan_node_GetInfo_Response_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_]{};
+    size_t size = sizeof(buffer);
+    REQUIRE(uavcan_node_GetInfo_Response_1_0_serialize_(&info, buffer, &size) == NUNAVUT_SUCCESS);
+
+    uavcan_node_GetInfo_Response_1_0 deserialized{};
+    std::memset(&deserialized, 0, sizeof(deserialized));
+    size_t deserialized_size = size;
+    REQUIRE(uavcan_node_GetInfo_Response_1_0_deserialize_(&deserialized, buffer, &deserialized_size) == NUNAVUT_SUCCESS);
+    REQUIRE(deserialized_size == size);
+
+    REQUIRE(deserialized.protocol_version.major == 1U);
+    REQUIRE(deserialized.protocol_version.minor == 0U);
+    REQUIRE(deserialized.hardware_version.major == 0U);
+    REQUIRE(deserialized.hardware_version.minor == 0U);
+    REQUIRE(deserialized.software_version.major == 1U);
+    REQUIRE(deserialized.software_version.minor == 0U);
+    REQUIRE(deserialized.software_vcs_revision_id == 0U);
+    REQUIRE(std::memcmp(deserialized.unique_id, info.unique_id, sizeof(info.unique_id)) == 0);
+    REQUIRE(deserialized.name.count == info.name.count);
+    REQUIRE(std::memcmp(deserialized.name.elements, info.name.elements, info.name.count) == 0);
+}
+
+TEST_CASE("GetInfo Response default-initializes to zeros by the library", "[cyphal][getinfo][response]") {
+    uavcan_node_GetInfo_Response_1_0 info{};
+    uavcan_node_GetInfo_Response_1_0_initialize_(&info);
+    REQUIRE(info.protocol_version.major == 0U);
+    REQUIRE(info.protocol_version.minor == 0U);
+    REQUIRE(info.unique_id[0] == 0U);
+    REQUIRE(info.name.count == 0U);
+}
+
+}    // namespace


### PR DESCRIPTION
Closes #44 (server half; client scanner is #45).

## Summary
Adds the service-side half of `uavcan.node.GetInfo.1.0` (port-ID 430) to `nucleo-cyphal`:

- `CyphalApp` gains a `UdpardRxRPCDispatcher` + a GetInfo **request** RX port (430).
- Lazy `ServiceDispatcherInit()` runs from `Execute()` once udpard is up.
- `OnReceiveUdp` routes service-multicast datagrams (`239.1.0.<node-id>`) to the RPC dispatcher; subject multicast still goes to the subject subscription.
- `ServiceResponseHandler()` builds an **assigned** identity (name `com.emrainey.superloop.nucleo`, versions, unique-id constants) and `udpardTxRespond()`s with the request's client node-ID and transfer-ID.

## Testing
- New host Catch2 test `test-cyphal-getinfo-server-none-all` (4 cases / 21 assertions): sealed request -> 0 bytes; request deserialize no-op; response round-trip; default-init.
- Passes on LLVM and AppleClang; M4/M7 cross builds green.
- `build-all-presets.py`: llvm + clang pass; `on-host-native-gcc` fails - pre-existing Darwin/homebrew gcc issue (`cstddef` missing in `module-core`), unrelated to this change.

## Notes
- All GetInfo defaults are zero; response uses `memset` instead of the generated `initialize_()` to dodge GCC `-Werror array-bounds` (documented in GOTCHAS.md).
- Identity uses assigned constants for now (not MAC-derived), per requirement.

Commits: AI (opencode/deepseek-v4-flash-free) implemented the feature/tests/docs; human reviewed the plan and selected the server-first split (#44/#45) and defined the identity contents.