### PR TITLE
stm32: fix H7 DBGMCU base in linkerscript (issue-50)

### DIFF
--- a/modules/stm32/linkerscripts/stm32h753zi-sections.ld
+++ b/modules/stm32/linkerscripts/stm32h753zi-sections.ld
@@ -204,7 +204,11 @@
     _cortex_itcm_control = ORIGIN(PPB) + 0x0EF90;
     _cortex_dtcm_control = ORIGIN(PPB) + 0x0EF94;
     _cortex_trace_port_inferface_unit = ORIGIN(PPB) + 0x40000;
-    _stm32_debug = ORIGIN(PPB) + 0x42000;
+
+    /* DBGMCU is not a CoreSight component; the core accesses it at 0x5C001000 (the
+       debugger uses the APB-D alias at 0xE00E1000). The F4-style address in the PPB
+       is not mapped on STM32H7. */
+    _stm32_debug = 0x5C001000;
 
     /* Provide the C++ mangled names */
     PROVIDE(_ZN6cortex11peripherals27instruction_trace_macrocellE = _cortex_instruction_trace_macrocell);


### PR DESCRIPTION
## Summary
`_stm32_debug` (and therefore `stm32::h7xx::debug`) was bound to `ORIGIN(PPB) + 0x42000` = `0xE0042000`, the F4 DBGMCU address. On STM32H7 the core accesses DBGMCU at `0x5C001000` (`0xE00E1000` is the debugger-only APB-D alias).

## Impact
`Timer::Initialize()` (modules/stm32/source/Timer2.cpp) sets `timer2_stop_in_debug = 1`, but the write landed on a dead address. `APB1LFZ1.DBG_TIM2` stayed 0, so TIM2 free-ran during debug halts — corrupting all while-halted TIM2 SR/CNT/overflow observations and making the timer look grossly inaccurate under debug.

## Fix
`_stm32_debug = 0x5C001000;` with an explanatory comment.

## Verification (on hardware via pylink-square-mcp)
- `stm32::h7xx::debug` binds to `0x5C001000`
- `APB1LFZ1.DBG_TIM2 = 1` after boot
- TIM2 freezes with the core; post-write SR=0x1E confirms UIF clears correctly (clear-on-zero)

Host unit tests 19/19 (LLVM + AppleClang); M4/M7 cross tests build. Fixes #50.